### PR TITLE
Fix add intracondition test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ ENV/
 .ropeproject
 
 .idea
+*.iml

--- a/rete/network.py
+++ b/rete/network.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import cStringIO
+from io import StringIO
 
 from rete.bind_node import BindNode
 from rete.filter_node import FilterNode
@@ -50,7 +50,7 @@ class Network:
                     child.left_activation(jr.owner, None)
 
     def dump(self):
-        self.buf = cStringIO.StringIO()
+        self.buf = StringIO()
         self.buf.write('digraph {\n')
         self.dump_beta(self.beta_root)
         self.dump_alpha(self.alpha_root)

--- a/rete/pnode.py
+++ b/rete/pnode.py
@@ -12,7 +12,7 @@ class PNode(BetaNode):
         super(PNode, self).__init__(children=children, parent=parent)
         self.items = items if items else []
         self.children = children if children else []
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
     def left_activation(self, token, wme, binding=None):

--- a/tests/test_helper_node.py
+++ b/tests/test_helper_node.py
@@ -33,17 +33,17 @@ def test_filter_compare():
 def test_bind():
     net = Network()
     c0 = Has('spu:1', 'sales', '$x')
-    b0 = Bind('len(set($x) & set(xrange(1, 100)))', '$num')
+    b0 = Bind('len(set($x) & set(range(1, 100)))', '$num')
     f0 = Filter('$num > 0')
     p0 = net.add_production(Rule(c0, b0, f0))
 
-    b1 = Bind('len(set($x) & set(xrange(100, 200)))', '$num')
+    b1 = Bind('len(set($x) & set(range(100, 200)))', '$num')
     p1 = net.add_production(Rule(c0, b1, f0))
 
-    b2 = Bind('len(set($x) & set(xrange(300, 400)))', '$num')
+    b2 = Bind('len(set($x) & set(range(300, 400)))', '$num')
     p2 = net.add_production(Rule(c0, b2, f0))
 
-    net.add_wme(WME('spu:1', 'sales', 'xrange(50, 110)'))
+    net.add_wme(WME('spu:1', 'sales', 'range(50, 110)'))
 
     assert len(p0.items) == 1
     assert len(p1.items) == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+from rete.network import Network, Rule
+from rete.common import Has, WME
+
+
+def test_binding_should_not_match():
+
+    net = Network()
+    c0 = Has('foo', '$x', '$x')
+    p0 = net.add_production(Rule(c0))
+    net.add_wme(WME('foo', 'bar', 'baz'))
+
+    assert len(p0.items) == 0
+
+
+def test_should_match_one():
+
+    net = Network()
+    c0 = Has('foo', '$x', '$x')
+    p0 = net.add_production(Rule(c0))
+    net.add_wme(WME('foo', 'quux', 'quux'))
+
+    assert len(p0.items) == 1
+
+
+def test_all_variables():
+
+    net = Network()
+    c0 = Has('$x', '$y', '$y')
+    p0 = net.add_production(Rule(c0))
+    net.add_wme(WME('foo', 'bar', 'baz'))
+
+    assert len(p0.items) == 0
+
+
+def test_all_variables_the_same_should_match():
+
+    net = Network()
+    c0 = Has('$x', '$x', '$x')
+    p0 = net.add_production(Rule(c0))
+    net.add_wme(WME('foo', 'foo', 'foo'))
+
+    assert len(p0.items) == 1
+
+
+def test_all_variables_the_same_should_not_match():
+
+    net = Network()
+    c0 = Has('$x', '$x', '$x')
+    p0 = net.add_production(Rule(c0))
+    net.add_wme(WME('bar', 'foo', 'foo'))
+
+    assert len(p0.items) == 0
+
+
+def test_all_constants_the_same_should_match_one():
+
+    net = Network()
+    c0 = Has('foo', 'foo', 'foo')
+    p0 = net.add_production(Rule(c0))
+    net.add_wme(WME('foo', 'foo', 'foo'))
+
+    assert len(p0.items) == 1
+
+
+def test_all_constants_the_same_should_not_match():
+
+    net = Network()
+    c0 = Has('foo', 'foo', 'foo')
+    p0 = net.add_production(Rule(c0))
+    net.add_wme(WME('bar', 'foo', 'foo'))
+
+    assert len(p0.items) == 0
+
+
+def test_multiple_conditions_should_match_one():
+
+    net = Network()
+    c0 = Has('foo', '$x', '$y')
+    c1 = Has('$x', '$x', '$y')
+    c2 = Has('$x', 'foo', 'baz')
+    p0 = net.add_production(Rule(c0, c1, c2))
+    net.add_wme(WME('foo', 'foo', 'baz'))
+
+    assert len(p0.items) == 1
+
+
+def test_multiple_conditions_should_not_match():
+
+    net = Network()
+    c0 = Has('foo', '$x', '$y')
+    c1 = Has('foo', '$x', '$x')
+    c2 = Has('$x', '$y', 'baz')
+    p0 = net.add_production(Rule(c0, c1, c2))
+    net.add_wme(WME('foo', 'bar', 'baz'))
+
+    assert len(p0.items) == 0
+
+
+def test_multiple_conditions_all_variables_should_match_one():
+
+    net = Network()
+    c0 = Has('foo', 'foo', 'foo')
+    c1 = Has('$x', '$x', '$x')
+    c2 = Has('$x', 'foo', 'foo')
+    c3 = Has('foo', '$x', 'foo')
+    c4 = Has('$x', 'foo', '$x')
+    p0 = net.add_production(Rule(c0, c1, c2, c3, c4))
+    net.add_wme(WME('foo', 'foo', 'foo'))
+
+    assert len(p0.items) == 1
+
+
+def test_multiple_conditions_all_variables_should_match_one_2():
+
+    net = Network()
+    c0 = Has('$x', '$x', '$x')
+    c1 = Has('foo', '$x', 'foo')
+    p0 = net.add_production(Rule(c0, c1))
+    net.add_wme(WME('foo', 'foo', 'foo'))
+
+    assert len(p0.items) == 1

--- a/tests/test_integration_intraconditions.py
+++ b/tests/test_integration_intraconditions.py
@@ -3,7 +3,7 @@ from rete.network import Network, Rule
 from rete.common import Has, WME
 
 
-def test_binding_should_not_match():
+def test_recurring_vars_should_not_match():
 
     net = Network()
     c0 = Has('foo', '$x', '$x')
@@ -13,7 +13,7 @@ def test_binding_should_not_match():
     assert len(p0.items) == 0
 
 
-def test_should_match_one():
+def test_recurring_vars_should_match():
 
     net = Network()
     c0 = Has('foo', '$x', '$x')
@@ -23,7 +23,7 @@ def test_should_match_one():
     assert len(p0.items) == 1
 
 
-def test_all_variables():
+def test_recurring_vars_no_constants_should_not_match():
 
     net = Network()
     c0 = Has('$x', '$y', '$y')
@@ -33,7 +33,7 @@ def test_all_variables():
     assert len(p0.items) == 0
 
 
-def test_all_variables_the_same_should_match():
+def test_recurring_vars_no_constants_should_match():
 
     net = Network()
     c0 = Has('$x', '$x', '$x')
@@ -106,17 +106,6 @@ def test_multiple_conditions_all_variables_should_match_one():
     c3 = Has('foo', '$x', 'foo')
     c4 = Has('$x', 'foo', '$x')
     p0 = net.add_production(Rule(c0, c1, c2, c3, c4))
-    net.add_wme(WME('foo', 'foo', 'foo'))
-
-    assert len(p0.items) == 1
-
-
-def test_multiple_conditions_all_variables_should_match_one_2():
-
-    net = Network()
-    c0 = Has('$x', '$x', '$x')
-    c1 = Has('foo', '$x', 'foo')
-    p0 = net.add_production(Rule(c0, c1))
     net.add_wme(WME('foo', 'foo', 'foo'))
 
     assert len(p0.items) == 1


### PR DESCRIPTION
Should fix https://github.com/GNaive/naive-rete/issues/25

Added an intra-condition var consistency check on ConstantTestNode to fix issue on cases like `($x, A, $x)`

Also created `VarConsistencyTestNode` to cover the cases like `($x, $x, $y)` when no ConstantTestNode are instantiated

Couldn't find info on implementing this check (the rule itself not being seemingly useful) and the other option I could think of was to add a single check on AlphaMemory. 
Although that would cover the two cases with minimal fuss I didn't want to break the responsibilities as they are laid now.
